### PR TITLE
Configurable identifier formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ It's a server-side mod that exposes metrics of your Fabric server in [Prometheus
 So, it requires you to have at least Prometheus installed to collect provided metrics.
 I recommend also using [Grafana](https://grafana.com) to visualize data.
 
-If you want to get TPS and MSPT metrics, you should also install [Spark](https://spark.lucko.me) as mod for your Fabric server.
+If you want to get TPS and MSPT metrics, you should also install [Spark](https://spark.lucko.me) as mod for your Fabric
+server.
 
 ## Exposed metrics
 
@@ -44,30 +45,39 @@ To use this mod you should have at least Fabric server and Prometheus installed.
 1. Download the mod from [Releases](https://github.com/ruscalworld/fabric-exporter/releases) page.
 2. Drop downloaded mod jar to the `mods` folder.
 3. Start your server to generate config file.
-4. Open `config/exporter.properties`, ensure that `server-port` value is an open port that can be accessed by your Prometheus and change it if required.
+4. Open `config/exporter.properties`, ensure that `server-port` value is an open port that can be accessed by your
+   Prometheus and change it if required.
 5. Restart the server if you made changes in config.
 
 ### Configuring Prometheus
 
 1. Open your Prometheus config file (it located at `/etc/prometheus/prometheus.yml` by default).
+
 ```bash
 sudo nano /etc/prometheus/prometheus.yml
 ```
-2. Add FabricExporter endpoint to the `scrape_configs` section. 
-Don't forget to replace `127.0.0.1` with address of your server and `25585` with port specified in `server-port` property in `exporter.properties` file.
+
+2. Add FabricExporter endpoint to the `scrape_configs` section.
+   Don't forget to replace `127.0.0.1` with address of your server and `25585` with port specified in `server-port`
+   property in `exporter.properties` file.
+
 ```YAML
 - job_name: 'fabric'
   static_configs:
-    - targets: ['127.0.0.1:25585']
+    - targets: [ '127.0.0.1:25585' ]
 ```
+
 3. Restart Prometheus service.
+
 ```bash
 sudo service prometheus restart
 ```
 
 ### Importing Grafana dashboard
-If you want to use Grafana, you can use my dashboard as template. 
-I assume that you have already [created a Prometheus data source](https://prometheus.io/docs/visualization/grafana/) in Grafana.
+
+If you want to use Grafana, you can use my dashboard as template.
+I assume that you have already [created a Prometheus data source](https://prometheus.io/docs/visualization/grafana/) in
+Grafana.
 So, let's import [dashboard for FabricExporter](https://grafana.com/grafana/dashboards/14492).
 
 1. Log in to your Grafana and go to `Create -> Import` tab.
@@ -76,17 +86,19 @@ So, let's import [dashboard for FabricExporter](https://grafana.com/grafana/dash
 
 ## Configuring
 
-After your server starts, FabricExporter will create `exporter.properties` file in the `config` folder. 
+After your server starts, FabricExporter will create `exporter.properties` file in the `config` folder.
 You should use this file to configure the mod.
 In this file you can see some general settings and metrics settings.
 
 ### General settings
 
-| Property          | Description                                                      | Default value |
-|-------------------|------------------------------------------------------------------|---------------|
-| `server-port`     | Port on what the web server will listen for requests             | `25585`       |
-| `update-interval` | Interval between gauge metrics updates in milliseconds           | `1000`        |
-| `use-spark`       | If set to `false`, FabricExporter will be independent from Spark | `true`        |
+| Property                      | Description                                                                     | Default value |
+|-------------------------------|---------------------------------------------------------------------------------|---------------|
+| `server-port`                 | Port on what the web server will listen for requests                            | `25585`       |
+| `update-interval`             | Interval between gauge metrics updates in milliseconds                          | `1000`        |
+| `use-spark`                   | If set to `false`, FabricExporter will be independent from Spark                | `true`        |
+| `export-default-jvm-metrics`  | If set to `true`, advanced metrics for JVM will be exported                     | `true`        |
+| `strip-identifier-namespaces` | If set to `false`, FabricExporter will provide full identifiers in label values | `true`        |
 
 ### Metrics settings
 
@@ -98,4 +110,5 @@ If you can't find property for some metrics, you can manually add it.
 All metrics are enabled by default.
 
 ## License
+
 MIT license. Read more in [LICENSE](LICENSE)

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,14 +2,14 @@
 org.gradle.jvmargs=-Xmx2G
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.21.3
-yarn_mappings=1.21.3+build.2
+minecraft_version=1.21.4
+yarn_mappings=1.21.4+build.2
 loader_version=0.16.9
 # Mod Properties
-mod_version=1.0.12
+mod_version=1.0.13
 maven_group=ru.ruscalworld
 archives_base_name=fabricexporter
 # Dependencies
 # check this on https://modmuss50.me/fabric.html
-fabric_version=0.107.3+1.21.3
+fabric_version=0.112.0+1.21.4
 prometheus_version=0.16.0

--- a/src/main/java/ru/ruscalworld/fabricexporter/FabricExporter.java
+++ b/src/main/java/ru/ruscalworld/fabricexporter/FabricExporter.java
@@ -10,6 +10,7 @@ import net.minecraft.server.MinecraftServer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import ru.ruscalworld.fabricexporter.config.MainConfig;
+import ru.ruscalworld.fabricexporter.util.IdentifierFormatter;
 
 import java.io.IOException;
 import java.util.Optional;
@@ -22,6 +23,7 @@ public class FabricExporter implements ModInitializer {
     private MainConfig config;
     private HTTPServer httpServer;
     private MetricRegistry metricRegistry;
+    private IdentifierFormatter identifierFormatter;
 
     @Override
     public void onInitialize() {
@@ -40,6 +42,8 @@ public class FabricExporter implements ModInitializer {
             logger.warn("Spark mod is not installed, but \"use-spark\" property is enabled! TPS and MSPT metrics will be disabled.");
             logger.warn("To fix this, you should either set \"use-spark\" in exporter.properties to false or install Spark mod (https://spark.lucko.me).");
         }
+
+        this.setIdentifierFormatter(new IdentifierFormatter(config.shouldStripIdentifierNamespaces()));
 
         MetricRegistry metricRegistry = new MetricRegistry(this);
         metricRegistry.registerDefault();
@@ -108,5 +112,13 @@ public class FabricExporter implements ModInitializer {
 
     public static FabricExporter getInstance() {
         return instance;
+    }
+
+    public IdentifierFormatter getIdentifierFormatter() {
+        return identifierFormatter;
+    }
+
+    private void setIdentifierFormatter(IdentifierFormatter identifierFormatter) {
+        this.identifierFormatter = identifierFormatter;
     }
 }

--- a/src/main/java/ru/ruscalworld/fabricexporter/FabricExporter.java
+++ b/src/main/java/ru/ruscalworld/fabricexporter/FabricExporter.java
@@ -30,8 +30,8 @@ public class FabricExporter implements ModInitializer {
             config.load();
             this.setConfig(config);
         } catch (IOException e) {
-            FabricExporter.getLogger().fatal("Unable to load config");
-            e.printStackTrace();
+            logger.fatal("Unable to load config", e);
+            return;
         }
 
         Optional<ModContainer> spark = FabricLoader.getInstance().getModContainer("spark");
@@ -54,11 +54,11 @@ public class FabricExporter implements ModInitializer {
             try {
                 int port = this.getConfig().getPort();
                 this.setHttpServer(new HTTPServer(port));
-                FabricExporter.getLogger().info("Prometheus exporter server is now listening on port " + port);
+                logger.info("Prometheus exporter server is now listening on port {}", port);
 
                 this.getMetricRegistry().runUpdater();
             } catch (IOException e) {
-                e.printStackTrace();
+                logger.error("Unable to start prometheus exporter server", e);
             }
         });
 

--- a/src/main/java/ru/ruscalworld/fabricexporter/MetricRegistry.java
+++ b/src/main/java/ru/ruscalworld/fabricexporter/MetricRegistry.java
@@ -3,6 +3,7 @@ package ru.ruscalworld.fabricexporter;
 import io.prometheus.client.Collector;
 import io.prometheus.client.Counter;
 import io.prometheus.client.SimpleCollector;
+import org.jetbrains.annotations.NotNull;
 import ru.ruscalworld.fabricexporter.config.MainConfig;
 import ru.ruscalworld.fabricexporter.metrics.Metric;
 import ru.ruscalworld.fabricexporter.metrics.spark.MillisPerTick;
@@ -12,6 +13,7 @@ import ru.ruscalworld.fabricexporter.metrics.world.Entities;
 import ru.ruscalworld.fabricexporter.metrics.world.LoadedChunks;
 import ru.ruscalworld.fabricexporter.metrics.world.OnlinePlayers;
 import ru.ruscalworld.fabricexporter.metrics.world.TotalLoadedChunks;
+import ru.ruscalworld.fabricexporter.util.IdentifierFormatter;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -23,10 +25,12 @@ public class MetricRegistry {
     private final List<Metric> metrics = new ArrayList<>();
     private final HashMap<String, Collector> customMetrics = new HashMap<>();
     private final Timer metricUpdaterTimer;
+    private final IdentifierFormatter identifierFormatter;
 
-    public MetricRegistry(FabricExporter exporter) {
+    public MetricRegistry(@NotNull FabricExporter exporter) {
         this.exporter = exporter;
         metricUpdaterTimer = new Timer("Metric Updater Timer");
+        identifierFormatter = exporter.getIdentifierFormatter();
     }
 
     public void runUpdater() {
@@ -37,10 +41,10 @@ public class MetricRegistry {
     }
 
     public void registerDefault() {
-        this.registerMetric(new OnlinePlayers());
-        this.registerMetric(new Entities());
-        this.registerMetric(new LoadedChunks());
-        this.registerMetric(new TotalLoadedChunks());
+        this.registerMetric(new OnlinePlayers(identifierFormatter));
+        this.registerMetric(new Entities(identifierFormatter));
+        this.registerMetric(new LoadedChunks(identifierFormatter));
+        this.registerMetric(new TotalLoadedChunks(identifierFormatter));
 
         if (this.getExporter().getConfig().shouldUseSpark()) {
             this.registerMetric(new TicksPerSecond());

--- a/src/main/java/ru/ruscalworld/fabricexporter/config/MainConfig.java
+++ b/src/main/java/ru/ruscalworld/fabricexporter/config/MainConfig.java
@@ -9,6 +9,7 @@ public class MainConfig extends Config {
     private int updateInterval;
     private boolean useSpark;
     private boolean exportJvmDefaults;
+    private boolean stripIdentifierNamespaces;
 
     public MainConfig(String name) {
         super(name);
@@ -27,6 +28,7 @@ public class MainConfig extends Config {
         this.setShouldUseSpark(properties.getProperty("use-spark", "true").equalsIgnoreCase("true"));
 
         this.setShouldExportJvmDefaults(properties.getProperty("export-default-jvm-metrics", "true").equalsIgnoreCase("true"));
+        this.setShouldStripIdentifierNamespaces(properties.getProperty("strip-identifier-namespaces", "true").equalsIgnoreCase("true"));
     }
 
     public int getPort() {
@@ -59,5 +61,13 @@ public class MainConfig extends Config {
 
     public void setShouldExportJvmDefaults(boolean exportJvmDefaults) {
         this.exportJvmDefaults = exportJvmDefaults;
+    }
+
+    public boolean shouldStripIdentifierNamespaces() {
+        return stripIdentifierNamespaces;
+    }
+
+    public void setShouldStripIdentifierNamespaces(boolean stripIdentifierNamespaces) {
+        this.stripIdentifierNamespaces = stripIdentifierNamespaces;
     }
 }

--- a/src/main/java/ru/ruscalworld/fabricexporter/metrics/world/LoadedChunks.java
+++ b/src/main/java/ru/ruscalworld/fabricexporter/metrics/world/LoadedChunks.java
@@ -3,17 +3,20 @@ package ru.ruscalworld.fabricexporter.metrics.world;
 import net.minecraft.server.world.ServerWorld;
 import ru.ruscalworld.fabricexporter.FabricExporter;
 import ru.ruscalworld.fabricexporter.metrics.Metric;
-import ru.ruscalworld.fabricexporter.util.TextUtil;
+import ru.ruscalworld.fabricexporter.util.IdentifierFormatter;
 
 public class LoadedChunks extends Metric {
-    public LoadedChunks() {
+    private final IdentifierFormatter identifierFormatter;
+
+    public LoadedChunks(IdentifierFormatter identifierFormatter) {
         super("loaded_chunks", "Amount of currently loaded chunks on server", "world");
+        this.identifierFormatter = identifierFormatter;
     }
 
     @Override
     public void update(FabricExporter exporter) {
         for (ServerWorld world : exporter.getServer().getWorlds()) {
-            this.getGauge().labels(TextUtil.getWorldName(world)).set(world.getChunkManager().getLoadedChunkCount());
+            this.getGauge().labels(identifierFormatter.getWorldName(world)).set(world.getChunkManager().getLoadedChunkCount());
         }
     }
 }

--- a/src/main/java/ru/ruscalworld/fabricexporter/metrics/world/OnlinePlayers.java
+++ b/src/main/java/ru/ruscalworld/fabricexporter/metrics/world/OnlinePlayers.java
@@ -3,17 +3,20 @@ package ru.ruscalworld.fabricexporter.metrics.world;
 import net.minecraft.server.world.ServerWorld;
 import ru.ruscalworld.fabricexporter.FabricExporter;
 import ru.ruscalworld.fabricexporter.metrics.Metric;
-import ru.ruscalworld.fabricexporter.util.TextUtil;
+import ru.ruscalworld.fabricexporter.util.IdentifierFormatter;
 
 public class OnlinePlayers extends Metric {
-    public OnlinePlayers() {
+    private final IdentifierFormatter identifierFormatter;
+
+    public OnlinePlayers(IdentifierFormatter identifierFormatter) {
         super("players_online", "Amount of currently online players on the server", "world");
+        this.identifierFormatter = identifierFormatter;
     }
 
     @Override
     public void update(FabricExporter exporter) {
         for (ServerWorld world : exporter.getServer().getWorlds()) {
-            this.getGauge().labels(TextUtil.getWorldName(world)).set(world.getPlayers().size());
+            this.getGauge().labels(identifierFormatter.getWorldName(world)).set(world.getPlayers().size());
         }
     }
 }

--- a/src/main/java/ru/ruscalworld/fabricexporter/metrics/world/TotalLoadedChunks.java
+++ b/src/main/java/ru/ruscalworld/fabricexporter/metrics/world/TotalLoadedChunks.java
@@ -3,17 +3,20 @@ package ru.ruscalworld.fabricexporter.metrics.world;
 import net.minecraft.server.world.ServerWorld;
 import ru.ruscalworld.fabricexporter.FabricExporter;
 import ru.ruscalworld.fabricexporter.metrics.Metric;
-import ru.ruscalworld.fabricexporter.util.TextUtil;
+import ru.ruscalworld.fabricexporter.util.IdentifierFormatter;
 
 public class TotalLoadedChunks extends Metric {
-    public TotalLoadedChunks() {
+    private final IdentifierFormatter identifierFormatter;
+
+    public TotalLoadedChunks(IdentifierFormatter identifierFormatter) {
         super("total_loaded_chunks", "Amount of total loaded chunks on server", "world");
+        this.identifierFormatter = identifierFormatter;
     }
 
     @Override
     public void update(FabricExporter exporter) {
         for (ServerWorld world : exporter.getServer().getWorlds()) {
-            this.getGauge().labels(TextUtil.getWorldName(world)).set(world.getChunkManager().getTotalChunksLoadedCount());
+            this.getGauge().labels(identifierFormatter.getWorldName(world)).set(world.getChunkManager().getTotalChunksLoadedCount());
         }
     }
 }

--- a/src/main/java/ru/ruscalworld/fabricexporter/util/IdentifierFormatter.java
+++ b/src/main/java/ru/ruscalworld/fabricexporter/util/IdentifierFormatter.java
@@ -1,0 +1,22 @@
+package ru.ruscalworld.fabricexporter.util;
+
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.Identifier;
+import org.jetbrains.annotations.NotNull;
+
+public class IdentifierFormatter {
+    private final boolean stripNamespaces;
+
+    public IdentifierFormatter(boolean stripNamespaces) {
+        this.stripNamespaces = stripNamespaces;
+    }
+
+    public String format(Identifier identifier) {
+        if (this.stripNamespaces) return identifier.getPath();
+        return identifier.toString();
+    }
+
+    public String getWorldName(@NotNull ServerWorld world) {
+        return this.format(world.getRegistryKey().getValue());
+    }
+}

--- a/src/main/java/ru/ruscalworld/fabricexporter/util/TextUtil.java
+++ b/src/main/java/ru/ruscalworld/fabricexporter/util/TextUtil.java
@@ -1,9 +1,0 @@
-package ru.ruscalworld.fabricexporter.util;
-
-import net.minecraft.server.world.ServerWorld;
-
-public class TextUtil {
-    public static String getWorldName(ServerWorld world) {
-        return world.getRegistryKey().getValue().getPath();
-    }
-}

--- a/src/main/resources/config/exporter.properties
+++ b/src/main/resources/config/exporter.properties
@@ -19,6 +19,12 @@ use-spark=true
 # Default: true
 export-default-jvm-metrics=true
 
+# Should FabricExporter provide only identifier paths without namespaces in metric labels?
+# Label values without namespaces look more cleanly, but this could cause conflicts if your mods provide multiple
+# identifiers with same paths.
+# Default: true
+strip-identifier-namespaces=true
+
 # You can disable any metric that registered via MetricRegistry (all metrics by default) using the settings below
 # Names of properties consist of "enable" and metric name without prefix and "_" replaced with "-"
 # For example, if you want to disable "minecraft_players_online", you should set "enable-players-online" to "false"


### PR DESCRIPTION
closes #19 

This PR adds `strip-identifier-namespaces` config option which defaults to `true`. Changing it to `false` makes mod to respect the namespaces of identifiers which can be useful when mods provide identifiers with same paths causing conflicts.